### PR TITLE
Json path : fix some paths not handled correctly

### DIFF
--- a/json-glib/json-path.c
+++ b/json-glib/json-path.c
@@ -376,7 +376,7 @@ json_path_compile (JsonPath    *path,
                 return FALSE;
               }
 
-            if (!(*(p + 1) == '.' || *(p + 1) == '['))
+            if (!(*(p + 1) == '.' || *(p + 1) == '[' || *(p + 1) == '\0'))
               {
                 /* translators: the %c is the invalid character */
                 g_set_error (error, JSON_PATH_ERROR,
@@ -737,7 +737,10 @@ walk_path_node (GList      *path,
   switch (node->node_type)
     {
     case JSON_PATH_NODE_ROOT:
-      walk_path_node (path->next, root, results);
+      if (path->next != NULL)
+          walk_path_node (path->next, root, results);
+      else
+          json_array_add_element (results, json_node_copy (root));
       break;
 
     case JSON_PATH_NODE_CHILD_MEMBER:

--- a/json-glib/json-path.c
+++ b/json-glib/json-path.c
@@ -356,7 +356,8 @@ json_path_compile (JsonPath    *path,
 {
   const char *p, *end_p;
   PathNode *root = NULL;
-  GList *nodes, *l;
+  GList *nodes = NULL;
+  GList *l = NULL;
 
   p = expression;
 
@@ -635,6 +636,14 @@ json_path_compile (JsonPath    *path,
           break;
 
         default:
+          if (nodes == NULL)
+            {
+              g_set_error(error, JSON_PATH_ERROR,
+                          JSON_PATH_ERROR_INVALID_QUERY,
+                          _("Invalid first character '%c'"),
+                          *p);
+              return FALSE;
+            }
           break;
         }
 

--- a/json-glib/json-path.c
+++ b/json-glib/json-path.c
@@ -417,6 +417,14 @@ json_path_compile (JsonPath    *path,
                 while (!(*end_p == '.' || *end_p == '[' || *end_p == '\0'))
                   end_p += 1;
 
+                if (end_p == p + 1)
+                  {
+                    g_set_error_literal (error, JSON_PATH_ERROR,
+                                         JSON_PATH_ERROR_INVALID_QUERY,
+                                         _("Missing member name or wildcard after . character"));
+                    goto fail;
+                  }
+
                 node = g_new0 (PathNode, 1);
                 node->node_type = JSON_PATH_NODE_CHILD_MEMBER;
                 node->data.member_name = g_strndup (p + 1, end_p - p - 1);

--- a/json-glib/tests/path.c
+++ b/json-glib/tests/path.c
@@ -59,6 +59,20 @@ static const struct {
     JSON_PATH_ERROR_INVALID_QUERY,
   },
   {
+    "INVALID: invalid first character",
+    "/",
+    NULL,
+    FALSE,
+    JSON_PATH_ERROR_INVALID_QUERY,
+  },
+  {
+    "INVALID: missing member name or wildcard after dot",
+    "$.store.",
+    NULL,
+    FALSE,
+    JSON_PATH_ERROR_INVALID_QUERY,
+  },
+  {
     "Title of the first book in the store, using objct notation.",
     "$.store.book[0].title",
     "[\"Sayings of the Century\"]",
@@ -130,6 +144,16 @@ static const struct {
     "[\"red\",\"19.95\"]",
     TRUE,
   },
+  {
+    "The root node.",
+    "$",
+    "[{\"store\":{\"book\":[{\"category\":\"reference\",\"author\":\"Nigel Rees\",\"title\":\"Sayings of the Century\",\"price\":\"8.95\"},"
+                           "{\"category\":\"fiction\",\"author\":\"Evelyn Waugh\",\"title\":\"Sword of Honour\",\"price\":\"12.99\"},"
+                           "{\"category\":\"fiction\",\"author\":\"Herman Melville\",\"title\":\"Moby Dick\",\"isbn\":\"0-553-21311-3\",\"price\":\"8.99\"},"
+                           "{\"category\":\"fiction\",\"author\":\"J. R. R. Tolkien\",\"title\":\"The Lord of the Rings\",\"isbn\":\"0-395-19395-8\",\"price\":\"22.99\"}],"
+                 "\"bicycle\":{\"color\":\"red\",\"price\":\"19.95\"}}}]",
+    TRUE,
+  }
 };
 
 static void


### PR DESCRIPTION
Hi,

This patch fixes 3 cases which happen frequently:
- querying the root node using '$'
- calling with invalid path starting with invalid character (eg using a xpath in place of json path)
- calling with invalid path containing a dot not followed by a member name nor a wildcard

First pull request here, so let me know if I miss some important things ;-)
Cheers,
benjamin
